### PR TITLE
fix up initial login

### DIFF
--- a/src/node_modules/layout/layout-controller.coffee
+++ b/src/node_modules/layout/layout-controller.coffee
@@ -2,7 +2,7 @@ debug = require('debug')("layout")
 
 ### @ngInject ###
 module.exports = ($scope, GroupsStore, AuthService, AUTH_EVENTS, groups) ->
-  $scope.groups = groups
+  $scope.groups = groups || []
 
   $scope.$on AUTH_EVENTS.loginSuccess, ->
     debug("login success, fetching groups")

--- a/src/node_modules/layout/layout.coffee
+++ b/src/node_modules/layout/layout.coffee
@@ -4,10 +4,17 @@ module.exports = {
   template: require('./layout-template.html')
   controller: require('./layout-controller.coffee')
   resolve:
-    groups: (GroupsStore, AuthService) ->
+    groups: ($q, GroupsStore, AuthService) ->
       user = AuthService.getCurrentUser()
       if user
         GroupsStore.all(memberId: user.id)
+          .then null, (err) ->
+            if (err.name == "ForbiddenError")
+              # bad cookie
+              AuthService.logout()
+              AuthService.loginModalCtrl.open()
+            else
+              $q.reject(err)
       else
-        GroupsStore.all()
+        AuthService.loginModalCtrl.open()
 }


### PR DESCRIPTION
- if you're not logged in it opens login modal immediately rather than wait for Unauthorized error on initial groups fetch
- remove stale cookie if initial groups fetch receives Forbidden error (close #175)